### PR TITLE
Refactor title parsing in library page to use const for title variable improving code clarity and consistency.

### DIFF
--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -28,7 +28,7 @@ type ParsedTitle = {
 };
 
 function parseTitle(raw: string): ParsedTitle {
-  let title = raw.trim();
+  const title = raw.trim();
   const levelRegex = /\b([ABC][12](?:\s*[-–]\s*[ABC]?[12])?)\b/i;
   const levelMatch = title.match(levelRegex);
   const level = levelMatch ? levelMatch[1].replace(/\s*/g, "") : undefined;


### PR DESCRIPTION
Refactor title parsing in library page to use const for title variable improving code clarity and consistency.