### PR TITLE
Refactor getFromDict function to return string or string array

### DIFF
--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -427,16 +427,19 @@ export const dictionaries: Record<Locale, Dict> = {
   },
 };
 
-export function getFromDict(dict: unknown, path: string): string {
-  return (
-    path
-      .split(".")
-      .reduce(
-        (acc: unknown, key: string) =>
-          acc && typeof acc === "object" && acc !== null && key in acc
-            ? (acc as Record<string, unknown>)[key]
-            : null,
-        dict
-      ) ?? path
-  );
+export function getFromDict(dict: unknown, path: string): string | string[] {
+  const value = path
+    .split(".")
+    .reduce(
+      (acc, key) =>
+        acc && typeof acc === "object" && acc !== null && key in acc
+          ? (acc as Record<string, unknown>)[key]
+          : undefined,
+      dict
+    );
+  // Only return string, array, or fallback to empty string
+  if (typeof value === "string" || Array.isArray(value)) {
+    return value;
+  }
+  return "";
 }


### PR DESCRIPTION
Refactor getFromDict function to return string or string array, enhancing type safety and fallback handling. Simplify value retrieval logic and ensure consistent return types for improved code clarity.